### PR TITLE
Add scheduled cleanup for CombatTracker

### DIFF
--- a/Docs/CombatInitiativeTracker.md
+++ b/Docs/CombatInitiativeTracker.md
@@ -95,4 +95,4 @@ Removes a combatant by name.
 
 ### Tracker Expiration
 - Each tracker stores a `LastUpdatedAt` timestamp.
-- Trackers are automatically removed by the database if they haven't been updated for **7 days**.
+- A background cleanup service removes trackers that haven't been updated for **7 days**.

--- a/Modules/BotModule.cs
+++ b/Modules/BotModule.cs
@@ -44,5 +44,8 @@ public class BotModule : IBaseModule
         services.AddScoped<IGameHandler, CoinFlipHandler>();
         services.AddScoped<IGameHandlerRegistry, GameHandlerRegistry>();
         services.AddScoped<TurnOrderHandler>();
+
+        // Hosted services
+        services.AddHostedService<CombatTrackerCleanupService>();
     }
 }

--- a/Services/CombatTrackerCleanupService.cs
+++ b/Services/CombatTrackerCleanupService.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+
+public class CombatTrackerCleanupService : BackgroundService
+{
+    private readonly IServiceProvider _services;
+    private readonly ILogger<CombatTrackerCleanupService> _logger;
+    private readonly TimeSpan _interval = TimeSpan.FromHours(6);
+
+    public CombatTrackerCleanupService(IServiceProvider services, ILogger<CombatTrackerCleanupService> logger)
+    {
+        _services = services;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await CleanStaleTrackersAsync(stoppingToken);
+            try
+            {
+                await Task.Delay(_interval, stoppingToken);
+            }
+            catch (TaskCanceledException)
+            {
+                // Swallow if cancellation requested
+            }
+        }
+    }
+
+    private async Task CleanStaleTrackersAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = _services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<BotDbContext>();
+            var threshold = DateTime.UtcNow.AddDays(-7);
+            var staleTrackers = await db.CombatTrackers
+                .Where(t => t.LastUpdatedAt < threshold)
+                .ToListAsync(cancellationToken);
+
+            if (staleTrackers.Count > 0)
+            {
+                db.CombatTrackers.RemoveRange(staleTrackers);
+                await db.SaveChangesAsync(cancellationToken);
+                _logger.LogInformation("Removed {Count} stale combat trackers", staleTrackers.Count);
+            }
+            else
+            {
+                _logger.LogDebug("No stale combat trackers to remove");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error while cleaning stale combat trackers");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a background service that removes stale combat trackers
- wire the cleanup service in BotModule instead of Program
- log when no stale trackers exist and log removals/errors

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684387c33ef08320a948dd26ebfafac0